### PR TITLE
Adding 1.13 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.12-R0.1-SNAPSHOT</version>
+            <version>1.13-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.inventivetalent</groupId>
             <artifactId>reflectionhelper</artifactId>
-            <version>1.13.1-SNAPSHOT</version>
+            <version>1.14.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.inventivetalent</groupId>


### PR DESCRIPTION
- updating dependencies to Spigot 1.13 and ReflectionHelper 1.14.0
- adjusting reflection of the PacketPlayOutScoreboardTeam, which got changed in 1.13

This should break downwards compatibility and only fixes one known problem with 1.13 compatibility, there may be more.