### PR TITLE
Support 1.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,12 +92,12 @@
         <dependency>
             <groupId>org.inventivetalent.packetlistenerapi</groupId>
             <artifactId>api</artifactId>
-            <version>3.9.2-SNAPSHOT</version>
+            <version>3.9.4-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.inventivetalent</groupId>
             <artifactId>reflectionhelper</artifactId>
-            <version>1.17.2-SNAPSHOT</version>
+            <version>1.18.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.inventivetalent</groupId>
             <artifactId>reflectionhelper</artifactId>
-            <version>1.18.2-SNAPSHOT</version>
+            <version>1.18.3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
                             <artifactSet>
                                 <includes>
                                     <include>org.bstats:*</include>
-                                    <include>org.objenesis:*</include>
                                     <include>org.inventivetalent:glowapi**</include>
                                     <include>org.inventivetalent:reflectionhelper**</include>
                                     <include>org.inventivetalent:apimanager**</include>
@@ -61,10 +60,6 @@
                                 <relocation>
                                     <pattern>org.bstats</pattern>
                                     <shadedPattern>org.inventivetalent.glowapi</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.objenesis</pattern>
-                                    <shadedPattern>org.inventivetalent.glow.objenesis</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.inventivetalent.reflection</pattern>
@@ -108,11 +103,6 @@
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit-lite</artifactId>
             <version>1.7</version>
-        </dependency>
-        <dependency>
-            <groupId>org.objenesis</groupId>
-            <artifactId>objenesis</artifactId>
-            <version>3.2</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>org.bstats:*</include>
+                                    <include>org.objenesis:*</include>
                                     <include>org.inventivetalent:glowapi**</include>
                                     <include>org.inventivetalent:reflectionhelper**</include>
                                     <include>org.inventivetalent:apimanager**</include>
@@ -60,6 +61,10 @@
                                 <relocation>
                                     <pattern>org.bstats</pattern>
                                     <shadedPattern>org.inventivetalent.glowapi</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.objenesis</pattern>
+                                    <shadedPattern>org.inventivetalent.glow.objenesis</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.inventivetalent.reflection</pattern>
@@ -103,6 +108,11 @@
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit-lite</artifactId>
             <version>1.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+            <version>3.2</version>
         </dependency>
     </dependencies>
 

--- a/src/org/inventivetalent/glow/GlowAPI.java
+++ b/src/org/inventivetalent/glow/GlowAPI.java
@@ -24,7 +24,6 @@ import org.inventivetalent.reflection.resolver.MethodResolver;
 import org.inventivetalent.reflection.resolver.ResolverQuery;
 import org.inventivetalent.reflection.resolver.minecraft.NMSClassResolver;
 import org.inventivetalent.reflection.resolver.minecraft.OBCClassResolver;
-import org.objenesis.ObjenesisHelper;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
@@ -474,7 +473,7 @@ public class GlowAPI implements Listener {
 				}
 
 				if (MinecraftVersion.VERSION.newerThan(Minecraft.Version.v1_17_R1)) {
-					packetScoreboardTeam = PacketScoreboardTeamResolver.resolve(new Class[]{String.class, int.class, Optional.class, Collection.class}).newInstance(color.getTeamName(), mode, Optional.empty(), Lists.newArrayList());
+					packetScoreboardTeam = PacketScoreboardTeamResolver.resolve(new Class[]{String.class, int.class, Optional.class, Collection.class}).newInstance(color.getTeamName(), mode, Optional.empty(), entitiesList);
 				}
 			}
 

--- a/src/org/inventivetalent/glow/GlowAPI.java
+++ b/src/org/inventivetalent/glow/GlowAPI.java
@@ -259,16 +259,16 @@ public class GlowAPI implements Listener {
 	protected static void sendGlowPacket(Entity entity, boolean wasGlowing, boolean glowing, Player receiver) {
 		try {
 			if (PacketPlayOutEntityMetadata == null) {
-				PacketPlayOutEntityMetadata = NMS_CLASS_RESOLVER.resolve("PacketPlayOutEntityMetadata");
+				PacketPlayOutEntityMetadata = NMS_CLASS_RESOLVER.resolve("network.protocol.game.PacketPlayOutEntityMetadata");
 			}
 			if (DataWatcher == null) {
-				DataWatcher = NMS_CLASS_RESOLVER.resolve("DataWatcher");
+				DataWatcher = NMS_CLASS_RESOLVER.resolve("network.syncher.DataWatcher");
 			}
 			if (DataWatcherItem == null) {
-				DataWatcherItem = NMS_CLASS_RESOLVER.resolve("DataWatcher$Item");
+				DataWatcherItem = NMS_CLASS_RESOLVER.resolve("network.syncher.DataWatcherObject", "DataWatcher$Item");
 			}
 			if (Entity == null) {
-				Entity = NMS_CLASS_RESOLVER.resolve("Entity");
+				Entity = NMS_CLASS_RESOLVER.resolve("world.entity.Entity");
 			}
 			if (PacketPlayOutMetadataFieldResolver == null) {
 				PacketPlayOutMetadataFieldResolver = new FieldResolver(PacketPlayOutEntityMetadata);
@@ -344,13 +344,13 @@ public class GlowAPI implements Listener {
 	protected static void sendTeamPacket(Entity entity, Color color, boolean createNewTeam/*If true, we don't add any entities*/, boolean addEntity/*true->add the entity, false->remove the entity*/, String tagVisibility, String push, Player receiver) {
 		try {
 			if (PacketPlayOutScoreboardTeam == null) {
-				PacketPlayOutScoreboardTeam = NMS_CLASS_RESOLVER.resolve("PacketPlayOutScoreboardTeam");
+				PacketPlayOutScoreboardTeam = NMS_CLASS_RESOLVER.resolve("network.protocol.game.PacketPlayOutScoreboardTeam");
 			}
 			if (PacketScoreboardTeamFieldResolver == null) {
 				PacketScoreboardTeamFieldResolver = new FieldResolver(PacketPlayOutScoreboardTeam);
 			}
 			if(ChatComponentTextResolver == null) {
-				ChatComponentTextResolver = new ConstructorResolver(NMS_CLASS_RESOLVER.resolve("ChatComponentText"));
+				ChatComponentTextResolver = new ConstructorResolver(NMS_CLASS_RESOLVER.resolve("network.chat.ChatComponentText"));
 			}
 
 			Object packetScoreboardTeam = PacketPlayOutScoreboardTeam.newInstance();
@@ -390,10 +390,10 @@ public class GlowAPI implements Listener {
 
 	protected static void sendPacket(Object packet, Player p) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException, ClassNotFoundException, NoSuchFieldException, NoSuchMethodException {
 		if (EntityPlayerFieldResolver == null) {
-			EntityPlayerFieldResolver = new FieldResolver(NMS_CLASS_RESOLVER.resolve("EntityPlayer"));
+			EntityPlayerFieldResolver = new FieldResolver(NMS_CLASS_RESOLVER.resolve("server.level.EntityPlayer"));
 		}
 		if (PlayerConnectionMethodResolver == null) {
-			PlayerConnectionMethodResolver = new MethodResolver(NMS_CLASS_RESOLVER.resolve("PlayerConnection"));
+			PlayerConnectionMethodResolver = new MethodResolver(NMS_CLASS_RESOLVER.resolve("server.network.PlayerConnection"));
 		}
 
 		try {
@@ -541,13 +541,13 @@ public class GlowAPI implements Listener {
 				CraftWorldFieldResolver = new FieldResolver(obcClassResolver.resolve("CraftWorld"));
 			}
 			if (WorldFieldResolver == null) {
-				WorldFieldResolver = new FieldResolver(nmsClassResolver.resolve("World"));
+				WorldFieldResolver = new FieldResolver(nmsClassResolver.resolve("world.level.World"));
 			}
 			if (WorldServerFieldResolver == null) {
-				WorldServerFieldResolver = new FieldResolver(nmsClassResolver.resolve("WorldServer"));
+				WorldServerFieldResolver = new FieldResolver(nmsClassResolver.resolve("server.level.WorldServer"));
 			}
 			if (EntityMethodResolver == null) {
-				EntityMethodResolver = new MethodResolver(nmsClassResolver.resolve("Entity"));
+				EntityMethodResolver = new MethodResolver(nmsClassResolver.resolve("world.entity.Entity"));
 			}
 
 			Object nmsWorld = CraftWorldFieldResolver.resolve("world").get(world);

--- a/src/org/inventivetalent/glow/GlowAPI.java
+++ b/src/org/inventivetalent/glow/GlowAPI.java
@@ -53,6 +53,9 @@ public class GlowAPI implements Listener {
 	private static MethodResolver EntityMethodResolver;
 
 	//Scoreboard
+	private static Object nms$Scoreboard;
+	private static ArrayList<String> scoreboardTeamEntityList;
+
 	private static Class<?> Scoreboard; // >= 1.17
 	private static Class<?> ScoreboardTeam; // >= 1.17
 	private static Class<?> PacketPlayOutScoreboardTeam;
@@ -419,12 +422,13 @@ public class GlowAPI implements Listener {
 
 			final int mode = (createNewTeam ? 0 : addEntity ? 3 : 4); //Mode (0 = create, 3 = add entity, 4 = remove entity)
 
-			Object nms$Scoreboard;
 			Object nms$ScoreboardTeam = null;
 			Object packetScoreboardTeam = null;
 
 			if (MinecraftVersion.VERSION.newerThan(Minecraft.Version.v1_17_R1)) {
-				nms$Scoreboard = ScoreboardResolver.resolveFirstConstructor().newInstance();
+				if (nms$Scoreboard == null) {
+					nms$Scoreboard = ScoreboardResolver.resolveFirstConstructor().newInstance();
+				}
 				nms$ScoreboardTeam = ScoreboardTeamResolver.resolveFirstConstructor().newInstance(nms$Scoreboard, color.getTeamName());
 			} else {
 				packetScoreboardTeam = PacketPlayOutScoreboardTeam.newInstance();
@@ -461,7 +465,11 @@ public class GlowAPI implements Listener {
 
 				Collection<String> entitiesList;
 				if (MinecraftVersion.VERSION.newerThan(Minecraft.Version.v1_17_R1)) {
-					entitiesList = Lists.newArrayList();
+					if (scoreboardTeamEntityList == null) {
+						scoreboardTeamEntityList = Lists.newArrayList();
+					}
+					scoreboardTeamEntityList.clear();
+					entitiesList = scoreboardTeamEntityList;
 				} else {
 					entitiesList = ((Collection<String>) PacketScoreboardTeamFieldResolver.resolve("h").get(packetScoreboardTeam));
 				}

--- a/src/org/inventivetalent/glow/GlowAPI.java
+++ b/src/org/inventivetalent/glow/GlowAPI.java
@@ -467,7 +467,14 @@ public class GlowAPI implements Listener {
 
 		try {
 			Object handle = Minecraft.getHandle(p);
-			final Object connection = EntityPlayerFieldResolver.resolve("playerConnection").get(handle);
+			final Object connection;
+
+			if (MinecraftVersion.VERSION.newerThan(Minecraft.Version.v1_17_R1)) { // even playerConnection got changed!
+				connection = EntityPlayerFieldResolver.resolve("b").get(handle);
+			} else {
+				connection = EntityPlayerFieldResolver.resolve("playerConnection").get(handle);
+			}
+
 			PlayerConnectionMethodResolver.resolve("sendPacket").invoke(connection, packet);
 		} catch (ReflectiveOperationException e) {
 			throw new RuntimeException(e);


### PR DESCRIPTION
**Information**
NMS classes have changed completely in 1.17. They use `private final` fields which are hard to hijack directly.
Each commit represents an updated NMS functionality and a description of what changed.

To be honest, fixing the issues with 1.17 NMS wasn't as easy as it sounds.
But, I got it working finally! \o/ with some debug pain on the way.

**Requirements**
- Release of ReflectionHelper with InventivetalentDev/ReflectionHelper#48 and InventivetalentDev/ReflectionHelper#49

**Preview**
![image](https://user-images.githubusercontent.com/20463031/123402998-ff5a4b00-d5b0-11eb-8fcc-c5d343be90bd.png)
_Usage of **GlowAPI** in **Minecraft 1.17**_