### PR TITLE
Change to java 16 (fixes jitpack)

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,6 @@
+jdk:
+  - openjdk16
+before_install:
+  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
+  - source install-jdk.sh --feature 16
+  - jshell --version

--- a/pom.xml
+++ b/pom.xml
@@ -33,14 +33,14 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>16</source>
+                    <target>16</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.3.0-SNAPSHOT</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -136,4 +136,11 @@
             <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>maven-snapshots</id>
+            <url>https://repository.apache.org/content/repositories/snapshots/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION
This allows jitpack to build this correctly.

See example here: 
[![image](https://user-images.githubusercontent.com/15234414/138087804-a5bd2504-6c72-4b95-8bf7-c46995b2d5b8.png)](https://jitpack.io/#DevScyu/GlowAPI/052d37f136)

[Build Log](https://jitpack.io/com/github/DevScyu/GlowAPI/052d37f136/build.log)


Also fixes #82 