### PR TITLE
The Crouch Mystery

### DIFF
--- a/src/org/inventivetalent/glow/GlowAPI.java
+++ b/src/org/inventivetalent/glow/GlowAPI.java
@@ -644,7 +644,7 @@ public class GlowAPI extends PacketHandler implements Listener {
             if (dataWatcherItemAccessor == null) return;
 
             if (DataWatcherItemAccessorFieldResolver == null) {
-                DataWatcherItemAccessorFieldResolver = new FieldResolver(nmsClassResolver.resolve("net.minecraft.network.syncher.DataWatcherObject"));
+                DataWatcherItemAccessorFieldResolver = new FieldResolver(nmsClassResolver.resolve("network.syncher.DataWatcherObject"));
             }
 
             int id = (Integer) DataWatcherItemAccessorFieldResolver.resolve("a").get(dataWatcherItemAccessor);

--- a/src/org/inventivetalent/glow/GlowAPI.java
+++ b/src/org/inventivetalent/glow/GlowAPI.java
@@ -320,7 +320,7 @@ public class GlowAPI implements Listener {
             //Existing values
             Object dataWatcher = EntityMethodResolver.resolve("getDataWatcher", "ai").invoke(Minecraft.getHandle(entity));
             Class dataWatcherItemsType;
-            if (isPaper) {
+            if (isPaper || MinecraftVersion.VERSION.newerThan(Minecraft.Version.v1_19_R1)) {
                 dataWatcherItemsType = Class.forName("it.unimi.dsi.fastutil.ints.Int2ObjectMap");
             } else {
                 dataWatcherItemsType = Class.forName("org.bukkit.craftbukkit.libs.it.unimi.dsi.fastutil.ints.Int2ObjectMap");

--- a/src/org/inventivetalent/glow/GlowAPI.java
+++ b/src/org/inventivetalent/glow/GlowAPI.java
@@ -333,7 +333,7 @@ public class GlowAPI extends PacketHandler implements Listener {
             //Existing values
             Object dataWatcher = EntityMethodResolver.resolve("getDataWatcher", "ai").invoke(Minecraft.getHandle(entity));
             Class dataWatcherItemsType;
-            if (isPaper || MinecraftVersion.VERSION.newerThan(Minecraft.Version.v1_19_R1)) {
+            if (isPaper || MinecraftVersion.VERSION.newerThan(Minecraft.Version.v1_18_R1)) {
                 dataWatcherItemsType = Class.forName("it.unimi.dsi.fastutil.ints.Int2ObjectMap");
             } else {
                 dataWatcherItemsType = Class.forName("org.bukkit.craftbukkit.libs.it.unimi.dsi.fastutil.ints.Int2ObjectMap");

--- a/src/org/inventivetalent/glow/GlowAPI.java
+++ b/src/org/inventivetalent/glow/GlowAPI.java
@@ -593,11 +593,6 @@ public class GlowAPI extends PacketHandler implements Listener {
         }
     }
 
-    //This gets called either by #initAPI above or #initAPI in one of the requiring plugins
-    public void init(Plugin plugin) {
-        Bukkit.getPluginManager().registerEvents(this, plugin);
-    }
-
     @EventHandler
     public void onJoin(final PlayerJoinEvent event) {
         //Initialize the teams
@@ -743,7 +738,8 @@ public class GlowAPI extends PacketHandler implements Listener {
         }
     }
 
-    public GlowAPI() {
+    public GlowAPI(Plugin plugin) {
+        super(plugin);
     }
 
 }

--- a/src/org/inventivetalent/glow/GlowAPI.java
+++ b/src/org/inventivetalent/glow/GlowAPI.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class GlowAPI extends PacketHandler implements Listener {
 
-    private static Map<UUID, GlowData> dataMap = new HashMap<>();
+    private static final Map<UUID, GlowData> dataMap = new HashMap<>();
     private final static Map<Integer, UUID> entityById = new ConcurrentHashMap<>();
 
     private static final NMSClassResolver NMS_CLASS_RESOLVER = new NMSClassResolver();

--- a/src/org/inventivetalent/glow/GlowPlugin.java
+++ b/src/org/inventivetalent/glow/GlowPlugin.java
@@ -1,9 +1,15 @@
 package org.inventivetalent.glow;
 
 import org.bstats.bukkit.MetricsLite;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.inventivetalent.packetlistener.PacketListenerAPI;
 import org.inventivetalent.reflection.minecraft.Minecraft;
+
+import java.util.Random;
 
 public class GlowPlugin extends JavaPlugin {
 
@@ -23,6 +29,15 @@ public class GlowPlugin extends JavaPlugin {
 		}
 
 		new MetricsLite(this, 2190);
+
+		Bukkit.getPluginManager().registerEvents(new Listener() {
+
+			@EventHandler
+			public void on(PlayerInteractEvent event) {
+				GlowAPI.setGlowing(event.getPlayer(), GlowAPI.Color.values()[new Random().nextInt(GlowAPI.Color.values().length)], Bukkit.getOnlinePlayers());
+			}
+
+		}, this);
 	}
 
 	@Override

--- a/src/org/inventivetalent/glow/GlowPlugin.java
+++ b/src/org/inventivetalent/glow/GlowPlugin.java
@@ -2,13 +2,8 @@ package org.inventivetalent.glow;
 
 import org.bstats.bukkit.MetricsLite;
 import org.bukkit.Bukkit;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.inventivetalent.packetlistener.PacketListenerAPI;
-
-import java.util.Random;
 
 public class GlowPlugin extends JavaPlugin {
 
@@ -27,15 +22,6 @@ public class GlowPlugin extends JavaPlugin {
         PacketListenerAPI.addPacketHandler(glowAPI);
 
         new MetricsLite(this, 2190);
-
-        Bukkit.getPluginManager().registerEvents(new Listener() {
-
-            @EventHandler
-            public void on(PlayerInteractEvent event) {
-                GlowAPI.setGlowing(event.getPlayer(), GlowAPI.Color.values()[new Random().nextInt(GlowAPI.Color.values().length)], Bukkit.getOnlinePlayers());
-            }
-
-        }, this);
     }
 
     @Override

--- a/src/org/inventivetalent/glow/GlowPlugin.java
+++ b/src/org/inventivetalent/glow/GlowPlugin.java
@@ -2,6 +2,8 @@ package org.inventivetalent.glow;
 
 import org.bstats.bukkit.MetricsLite;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.inventivetalent.packetlistener.PacketListenerAPI;
+import org.inventivetalent.reflection.minecraft.Minecraft;
 
 public class GlowPlugin extends JavaPlugin {
 
@@ -16,8 +18,18 @@ public class GlowPlugin extends JavaPlugin {
 	@Override
 	public void onEnable() {
 		glowAPI.init(this);
+		if (Minecraft.MINECRAFT_VERSION.newerThan(Minecraft.Version.v1_19_R1)) {
+			PacketListenerAPI.addPacketHandler(glowAPI);
+		}
 
 		new MetricsLite(this, 2190);
+	}
+
+	@Override
+	public void onDisable() {
+		if (Minecraft.MINECRAFT_VERSION.newerThan(Minecraft.Version.v1_19_R1)) {
+			PacketListenerAPI.removePacketHandler(glowAPI);
+		}
 	}
 
 }

--- a/src/org/inventivetalent/glow/GlowPlugin.java
+++ b/src/org/inventivetalent/glow/GlowPlugin.java
@@ -7,44 +7,40 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.inventivetalent.packetlistener.PacketListenerAPI;
-import org.inventivetalent.reflection.minecraft.Minecraft;
 
 import java.util.Random;
 
 public class GlowPlugin extends JavaPlugin {
 
-	static GlowPlugin instance;
-	GlowAPI glowAPI = new GlowAPI();
+    static GlowPlugin instance;
+    GlowAPI glowAPI;
 
-	@Override
-	public void onLoad() {
-		instance = this;
-	}
+    @Override
+    public void onLoad() {
+        instance = this;
+        glowAPI = new GlowAPI(this);
+    }
 
-	@Override
-	public void onEnable() {
-		glowAPI.init(this);
-		if (Minecraft.MINECRAFT_VERSION.newerThan(Minecraft.Version.v1_19_R1)) {
-			PacketListenerAPI.addPacketHandler(glowAPI);
-		}
+    @Override
+    public void onEnable() {
+        Bukkit.getPluginManager().registerEvents(glowAPI, this);
+        PacketListenerAPI.addPacketHandler(glowAPI);
 
-		new MetricsLite(this, 2190);
+        new MetricsLite(this, 2190);
 
-		Bukkit.getPluginManager().registerEvents(new Listener() {
+        Bukkit.getPluginManager().registerEvents(new Listener() {
 
-			@EventHandler
-			public void on(PlayerInteractEvent event) {
-				GlowAPI.setGlowing(event.getPlayer(), GlowAPI.Color.values()[new Random().nextInt(GlowAPI.Color.values().length)], Bukkit.getOnlinePlayers());
-			}
+            @EventHandler
+            public void on(PlayerInteractEvent event) {
+                GlowAPI.setGlowing(event.getPlayer(), GlowAPI.Color.values()[new Random().nextInt(GlowAPI.Color.values().length)], Bukkit.getOnlinePlayers());
+            }
 
-		}, this);
-	}
+        }, this);
+    }
 
-	@Override
-	public void onDisable() {
-		if (Minecraft.MINECRAFT_VERSION.newerThan(Minecraft.Version.v1_19_R1)) {
-			PacketListenerAPI.removePacketHandler(glowAPI);
-		}
-	}
+    @Override
+    public void onDisable() {
+        PacketListenerAPI.removePacketHandler(glowAPI);
+    }
 
 }


### PR DESCRIPTION
_A mystery that awaits us_

It took about a week to figure out and solve the issue, probably @InventivetalentDev would have resolved it faster and quicker, but it was fun to solve for me. :)

## Description
It appears that when the player **sneaks**/**crouches** in 1.19+. The glow around the player vanishes sadly.

## Cause
After doing a deep investigation into NMS. I reached to this analysis provided in the picture below.

![glow-api-analysis](https://user-images.githubusercontent.com/20463031/186905971-8fac1fdd-bbc7-45a0-be1d-b8dd9047a4df.png)
_Analysis of outgoing packets from the server to the target (player)_

It appears that when the player **sneaks (crouches)** a metadata packet is sent with the sneaking flag enabled (and without the glow flag enabled as expected). What's interesting here is that the sneaking flag is stored in the `ENTITY_SHARED_FLAGS` data watcher object. (are we expecting many entities being able to sneak? I don't really know. It will be fun to see though. lol)

This metadata packet is sent from an update players function that gets triggered from `PlayerChunkMap` tick method. The entity tracker gets called (by the update players function) and sends to the player the metadata packet of its new state.

## Screenshots
![player-standing-with-glow](https://user-images.githubusercontent.com/20463031/186905871-87b9d612-2b45-4d35-89b0-2f4f7a15dc83.png)
- _Player standing but glowing as well as other entities around him_

![player-sneaking-with-glow](https://user-images.githubusercontent.com/20463031/186908766-c8fc5f0d-fe89-4928-b486-28cb28cfba1b.png)
- _Player sneaking but glowing as well as other entities around him_

## Solution
We inject a packet handler using [PacketListenerAPI](https://github.com/InventivetalentDev/PacketListenerAPI) to catch any metadata packet with the interested data watcher object (`ENTITY_SHARED_FLAGS`).

Then, we compare the glow data between the player who receives the packet and the entity thats the target of the glow flag in the metadata packet. We modify the packet when one of the parties are registered in the [GlowAPI](https://github.com/InventivetalentDev/GlowAPI). If not, we just ignore the packet and proceed to listen to other packets.

**Note:** I added a map to register the entity unique id (`UUID`) by the entity id. It helps to avoid the async access to Bukkit/CraftBukkit APIs. And, it provides easy access in general. When the entity id is not found we just ignore modifying the packet in general.

## Additional Fixes
- [92ca6052f702152b6ad4595b62287621c16549f7] Looking for libraries without the craftbukkit prefix (only for 1.19+)
- [2fb5d58f591124d331ebef2d82410bb4b6c0f5b3] Extending the class lookup to be used for 1.18+ versions.

## Notes
- Is the issue reproducible on Minecraft **1.18.x**?

## References
- #126
- #123
- #128
