### PR TITLE
Make name tag, push rules configurable and apply them for 1.17+

### DIFF
--- a/src/org/inventivetalent/glow/GlowAPI.java
+++ b/src/org/inventivetalent/glow/GlowAPI.java
@@ -76,6 +76,9 @@ public class GlowAPI extends PacketHandler implements Listener {
     private static ConstructorResolver PacketScoreboardTeamResolver; // >= 1.17
     private static ConstructorResolver PacketScoreboardTeamInfoResolver; // >= 1.17
 
+    private static MethodResolver EnumNameTagVisibilityResolver; // >= 1.17
+    private static MethodResolver EnumTeamPushResolver; // >= 1.17
+
     private static ConstructorResolver ChatComponentTextResolver;
     private static MethodResolver EnumChatFormatResolver;
     private static MethodResolver IChatBaseComponentMethodResolver;
@@ -465,26 +468,49 @@ public class GlowAPI extends PacketHandler implements Listener {
                     if (PacketScoreboardTeamInfoResolver == null) {
                         PacketScoreboardTeamInfoResolver = new ConstructorResolver(PacketPlayOutScoreboardTeam$info);
                     }
+                    if (EnumNameTagVisibilityResolver == null) {
+                        EnumNameTagVisibilityResolver = new MethodResolver(NMS_CLASS_RESOLVER.resolve(
+                                "world.scores.ScoreboardTeamBase$EnumNameTagVisibility"));
+                    }
+                    if (EnumTeamPushResolver == null) {
+                        EnumTeamPushResolver = new MethodResolver(NMS_CLASS_RESOLVER.resolve(
+                                "world.scores.ScoreboardTeamBase$EnumTeamPush"));
+                    }
 
-                    ScoreboardTeamMethodResolver.resolve(new ResolverQuery[]{
-                            new ResolverQuery("setDisplayName"),
-                            new ResolverQuery("a", NMS_CLASS_RESOLVER.resolve("network.chat.IChatBaseComponent")),
-                    }).invoke(nms$ScoreboardTeam, displayName);
-                    ScoreboardTeamMethodResolver.resolve(new ResolverQuery[]{
-                            new ResolverQuery("setPrefix"),
-                            new ResolverQuery("b", NMS_CLASS_RESOLVER.resolve("network.chat.IChatBaseComponent")),
-                    }).invoke(nms$ScoreboardTeam, prefix);
-                    ScoreboardTeamMethodResolver.resolve(new ResolverQuery[]{
-                            new ResolverQuery("setSuffix"),
-                            new ResolverQuery("c", NMS_CLASS_RESOLVER.resolve("network.chat.IChatBaseComponent")),
-                    }).invoke(nms$ScoreboardTeam, suffix);
-                    ScoreboardTeamMethodResolver.resolve(new ResolverQuery[]{
-                            new ResolverQuery("setColor"),
-                            new ResolverQuery("a", NMS_CLASS_RESOLVER.resolve("EnumChatFormat")),
-                    }).invoke(nms$ScoreboardTeam, color.packetValue);
+                    Object visibilityObj = EnumNameTagVisibilityResolver.resolve("valueOf")
+                            .invoke(null, tagVisibility.toUpperCase());
+                    Object pushObj = EnumTeamPushResolver.resolve("valueOf")
+                            .invoke(null, push.toUpperCase());
+
+                    ScoreboardTeamMethodResolver.resolve(
+                                    new ResolverQuery("setDisplayName"),
+                                    new ResolverQuery("a", NMS_CLASS_RESOLVER.resolve("network.chat.IChatBaseComponent")))
+                            .invoke(nms$ScoreboardTeam, displayName);
+                    ScoreboardTeamMethodResolver.resolve(
+                                    new ResolverQuery("setPrefix"),
+                                    new ResolverQuery("b", NMS_CLASS_RESOLVER.resolve("network.chat.IChatBaseComponent")))
+                            .invoke(nms$ScoreboardTeam, prefix);
+                    ScoreboardTeamMethodResolver.resolve(
+                                    new ResolverQuery("setSuffix"),
+                                    new ResolverQuery("c", NMS_CLASS_RESOLVER.resolve("network.chat.IChatBaseComponent")))
+                            .invoke(nms$ScoreboardTeam, suffix);
+                    ScoreboardTeamMethodResolver.resolve(
+                                    new ResolverQuery("setColor"),
+                                    new ResolverQuery("a", NMS_CLASS_RESOLVER.resolve("EnumChatFormat")))
+                            .invoke(nms$ScoreboardTeam, color.packetValue);
+                    ScoreboardTeamMethodResolver.resolve(
+                                    new ResolverQuery("setNameTagVisibilityRule"),
+                                    new ResolverQuery("a", NMS_CLASS_RESOLVER.resolve("world.scores.ScoreboardTeamBase$EnumNameTagVisibility")))
+                            .invoke(nms$ScoreboardTeam, visibilityObj);
+                    ScoreboardTeamMethodResolver.resolve(
+                                    new ResolverQuery("setCollisionRule"),
+                                    new ResolverQuery("a", NMS_CLASS_RESOLVER.resolve("world.scores.ScoreboardTeamBase$EnumTeamPush")))
+                            .invoke(nms$ScoreboardTeam, pushObj);
 
                     Object packetScoreboardTeamInfo = PacketScoreboardTeamInfoResolver.resolveFirstConstructor().newInstance(nms$ScoreboardTeam);
-                    packetScoreboardTeam = PacketScoreboardTeamResolver.resolve(new Class[]{String.class, int.class, Optional.class, Collection.class}).newInstance(color.getTeamName(), mode, Optional.of(packetScoreboardTeamInfo), ImmutableList.of());
+                    packetScoreboardTeam = PacketScoreboardTeamResolver.resolve(
+                                    new Class[]{String.class, int.class, Optional.class, Collection.class})
+                            .newInstance(color.getTeamName(), mode, Optional.of(packetScoreboardTeamInfo), ImmutableList.of());
                 } else {
                     PacketScoreboardTeamFieldResolver.resolve("g").set(packetScoreboardTeam, color.packetValue);//Color -> this is what we care about
 

--- a/src/org/inventivetalent/glow/GlowPlugin.java
+++ b/src/org/inventivetalent/glow/GlowPlugin.java
@@ -2,8 +2,12 @@ package org.inventivetalent.glow;
 
 import org.bstats.bukkit.MetricsLite;
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.inventivetalent.packetlistener.PacketListenerAPI;
+
+import java.io.File;
+import java.io.IOException;
 
 public class GlowPlugin extends JavaPlugin {
 
@@ -14,6 +18,7 @@ public class GlowPlugin extends JavaPlugin {
     public void onLoad() {
         instance = this;
         glowAPI = new GlowAPI(this);
+        loadDefaults();
     }
 
     @Override
@@ -29,4 +34,49 @@ public class GlowPlugin extends JavaPlugin {
         PacketListenerAPI.removePacketHandler(glowAPI);
     }
 
+    private void loadDefaults() {
+        FileConfiguration configuration;
+        File dataFolder = getDataFolder();
+
+        if (!dataFolder.exists()) {
+            dataFolder.mkdirs();
+
+            // Fill the configuration with current values
+            configuration = getConfig();
+            configuration.set("nameTagVisibility", GlowAPI.TEAM_TAG_VISIBILITY);
+            configuration.set("collision", GlowAPI.TEAM_PUSH);
+
+            try {
+                configuration.save(new File(dataFolder, "config.yml"));
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to save default config", e);
+            }
+        } else {
+            configuration = getConfig();
+        }
+
+        String visibility = configuration.getString("nameTagVisibility");
+        if (visibility != null) {
+            if (!visibility.equals("always")
+                    && !visibility.equals("hideForOtherTeams")
+                    && !visibility.equals("hideForOwnTeam")
+                    && !visibility.equals("never")) {
+                getLogger().warning("Ignored unknown nameTagVisibility default value: '" + visibility + "'");
+            } else {
+                GlowAPI.TEAM_TAG_VISIBILITY = visibility;
+            }
+        }
+
+        String push = configuration.getString("collision");
+        if (push != null) {
+            if (!push.equals("always")
+                    && !push.equals("pushOtherTeams")
+                    && !push.equals("pushOwnTeam")
+                    && !push.equals("never")) {
+                getLogger().warning("Ignored unknown collision default value: '" + push + "'");
+            } else {
+                GlowAPI.TEAM_PUSH = push;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Currently, name tag visibility and collision default values are not user-friendly configurable so users of GlowAPI have to manually modify them like this:
```java
GlowAPI.TEAM_TAG_VISIBILITY = ...
GlowAPI.TEAM_PUSH = ...
```
Moreover, these are not applied for versions above 1.17 since setters are not being called.

This PR aims to fix both of these concerns mainly to allow visual compatibility with plugins that add custom nameplates: 

![image](https://user-images.githubusercontent.com/38561919/205756393-0239eab6-1837-4bad-aff8-3d242f360758.png)


